### PR TITLE
Add callback url option to fix regression for OAuth2 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,31 @@ Or install it yourself as:
 
 ## Basic Usage
 
-### For Rack-based applications
+For Rack-based applications
+```ruby
+use OmniAuth::Builder do
+  provider :medium, ENV['MEDIUM_CLIENT_ID'], ENV['MEDIUM_CLIENT_SECRET'], scope: 'basicProfile,listPublications'
+end
+```
 
-    use OmniAuth::Builder do
-      provider :medium, ENV['MEDIUM_CLIENT_ID'], ENV['MEDIUM_CLIENT_SECRET'], scope: 'basicProfile,listPublications'
-    end
+In Rails, you'll want to add to the middleware stack:
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider : medium, ENV['MEDIUM_CLIENT_ID'], ENV['MEDIUM_CLIENT_SECRET'], scope: 'basicProfile,listPublications'
+end
+```
 
-### In Rails, you'll want to add to the middleware stack:
-	Rails.application.config.middleware.use OmniAuth::Builder do
-	  provider : medium, ENV['MEDIUM_CLIENT_ID'], ENV['MEDIUM_CLIENT_SECRET'], scope: 'basicProfile,listPublications'
-	end
-	
+Or with Devise to your `config/initializers/devise.rb`
+
+```ruby
+config.omniauth :medium, ENV['MEDIUM_CLIENT_ID'], ENV['MEDIUM_CLIENT_SECRET'], scope: 'basicProfile,listPublications', callback_url: 'http://example.com/users/auth/medium/callback'
+```
+**Starting from version 1.4 in omniauth-oauth2 you must provide same callback url you have provided on API dashboard otherwise authentication won't work.**
+
 See the [example Sinatra app](https://github.com/adamkirkwood/omniauth-medium/tree/master/examples/sinatra) for a full example.
 
 For more information on interfacing with Medium's API, head over to their [documentation](https://github.com/Medium/medium-api-docs).
-	
+
 
 ## Auth Hash Schema
 OmniAuth will return an authentication hash similar to the example below. Learn more about the [Auth Hash Schema](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema).

--- a/lib/omniauth-medium/version.rb
+++ b/lib/omniauth-medium/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Medium
-    VERSION = '0.1.1'
+    VERSION = '0.1.1'.freeze
   end
 end

--- a/lib/omniauth-medium/version.rb
+++ b/lib/omniauth-medium/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Medium
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.1.2'.freeze
   end
 end

--- a/lib/omniauth/strategies/medium.rb
+++ b/lib/omniauth/strategies/medium.rb
@@ -5,7 +5,7 @@ module OmniAuth
     # Oauth2 strategy for medium.com
     class Medium < OmniAuth::Strategies::OAuth2
       option :name, 'medium'
-      option :scope, 'basicProfile,listPublications'
+      option :scope, 'basicProfile,publishPost'
 
       option :client_options,
              site: 'https://api.medium.com/v1',

--- a/lib/omniauth/strategies/medium.rb
+++ b/lib/omniauth/strategies/medium.rb
@@ -2,19 +2,25 @@ require 'omniauth-oauth2'
 
 module OmniAuth
   module Strategies
+    # Oauth2 strategy for medium.com
     class Medium < OmniAuth::Strategies::OAuth2
       option :name, 'medium'
-      option :scope, 'basicProfile,publishPost'
+      option :scope, 'basicProfile,listPublications'
 
-      option :client_options, {
-        site: 'https://api.medium.com/v1',
-        authorize_url: 'https://medium.com/m/oauth/authorize',
-        token_url: "https://api.medium.com/v1/tokens"
-      }
+      option :client_options,
+             site: 'https://api.medium.com/v1',
+             authorize_url: 'https://medium.com/m/oauth/authorize',
+             token_url: 'https://api.medium.com/v1/tokens'
 
-      uid { info["id"] }
+      uid { info['id'] }
 
-      info { @info ||= access_token.get("me").parsed["data"] }
+      info { @info ||= access_token.get('me').parsed['data'] }
+
+      def callback_url
+        # Fixes regression in omniauth-oauth2 v1.4.0 by
+        # https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
+        options[:callback_url] || (full_host + script_name + callback_path)
+      end
     end
   end
 end

--- a/omniauth-medium.gemspec
+++ b/omniauth-medium.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.7'
   spec.add_development_dependency 'rack-test'
 
-  spec.add_runtime_dependency 'omniauth-oauth2', '1.3.1'
+  spec.add_runtime_dependency 'omniauth-oauth2', '~> 1.0'
 end


### PR DESCRIPTION
* Update some syntax
* Fixes regression in omniauth-oauth2 v1.4.0 by intridea/omniauth-oauth2@85fdbe1
* Update readme
* Bump version
* Make `omniauth-oauth2` support ~> 1.0